### PR TITLE
Added numba signature to _cycle to prevent CPU Dispatcher error

### DIFF
--- a/pyrb/solvers.py
+++ b/pyrb/solvers.py
@@ -37,7 +37,8 @@ def accelarate(_varphi, r, s, u, alpha=10, tau=2):
     return _varphi, u
 
 
-@numba.njit
+@numba.jit('Tuple((float64[:], float64[:], float64))(float64[:], float64, float64[:], float64, float64, float64[:], float64[:], int32[:], float64[:,:], float64, float64[:,:])',
+      nopython=True)
 def _cycle(x, c, var, _varphi, sigma_x, Sx, budgets, pi, bounds, lambda_log, cov):
     """
     Internal numba function for computing one cycle of the CCD algorithm.


### PR DESCRIPTION
The only issued created in this repo concerns an error that occurs when numba tries to guess the variable types. Some claimed that updating either numpy of pandas version corrects the problem. I have successfullyused it in one computer and had the same error in other. This declaration of types solved the problem.