### PR TITLE
Added negative values validation

### DIFF
--- a/pyrb/validation.py
+++ b/pyrb/validation.py
@@ -48,7 +48,7 @@ def check_risk_budget(riskbudgets, n):
         return
     if np.isnan(riskbudgets).sum() > 0:
         raise ValueError("Risk budget contains missing values")
-    if (riskbudgets < 0).sum() > 0:
+    if (np.array(riskbudgets) < 0).sum() > 0:
         raise ValueError("Risk budget contains negative values")
     if n != len(riskbudgets):
         raise ValueError("Risk budget size is not equal to the number of asset.")

--- a/pyrb/validation.py
+++ b/pyrb/validation.py
@@ -48,6 +48,8 @@ def check_risk_budget(riskbudgets, n):
         return
     if np.isnan(riskbudgets).sum() > 0:
         raise ValueError("Risk budget contains missing values")
+    if (riskbudgets < 0).sum() > 0:
+        raise ValueError("Risk budget contains negative values")
     if n != len(riskbudgets):
         raise ValueError("Risk budget size is not equal to the number of asset.")
     if all(v < RISK_BUDGET_TOL for v in riskbudgets):


### PR DESCRIPTION
Several times it took me a long time do debug some backtests because at some point I was sending negative risk budget values and thus receiving NaNs as result. Had I had a crash with the proper warning it would've saved me lots of times. So i decided to add that!